### PR TITLE
固件安装兼容3.35.0及以后

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Xposed插件启用Mi Fitness第三方小程序安装卸载，表盘安装，固件安装。
 
-激活插件后会将Profile->About this app->User Agreemnt页面替换为隐藏的小程序安装界面。
+激活插件后会将Profile->About this app->User Agreement页面替换为隐藏的小程序安装界面。
 
 ## 注意
 
@@ -12,22 +12,22 @@ Xposed插件启用Mi Fitness第三方小程序安装卸载，表盘安装，固�
 
 ### 表盘安装
 
-点击Profile->About this app->User Agreemnt后在弹窗中选择WatchFace。不需要输入包名，点击install third app选择表盘文件。等待安装完成。
+点击Profile->About this app->User Agreement后在弹窗中选择WatchFace。不需要输入包名，点击install third app选择表盘文件。等待安装完成。
 
 ### 固件安装
 
 **注意该功能可能导致设备变砖，请谨慎使用**
 
-点击Profile->About this app->User Agreemnt后在弹窗中选择Firmware。不需要输入包名，点击install third app选择固件文件。在更新页面点击Download。
+点击Profile->About this app->User Agreement后在弹窗中选择Firmware。不需要输入包名，点击install third app选择固件文件。在更新页面点击Download。
 
 ### 小程序安装
 
-点击Profile->About this app->User Agreemnt后在弹窗中选择App。先输入包名后点击install third app选择小程序文件，安装时可以随便输入包名。仅卸载时需要完整包名。
+点击Profile->About this app->User Agreement后在弹窗中选择App。先输入包名后点击install third app选择小程序文件，安装时可以随便输入包名。仅卸载时需要完整包名。
 
 ### 日志拉取
 
-点击Profile->About this app->User Agreemnt后在弹窗中选择Pull log。日志会输出到/sdcard/Android/data/[应用包名]/files/log/devicelog/
+点击Profile->About this app->User Agreement后在弹窗中选择Pull log。日志会输出到/sdcard/Android/data/[应用包名]/files/log/devicelog/
 
 ### 获取EncryptKey
 
-点击Profile->About this app->User Agreemnt后在弹窗中选择Encrypt Key。获取当前设备上保存的EncryptKey信息。输出格式为：设备Did: [设备名称, Encrypt Key]
+点击Profile->About this app->User Agreement后在弹窗中选择Encrypt Key。获取当前设备上保存的EncryptKey信息。输出格式为：设备Did: [设备名称, Encrypt Key]

--- a/app/src/main/java/test/hook/debug/xp/Install.java
+++ b/app/src/main/java/test/hook/debug/xp/Install.java
@@ -121,8 +121,8 @@ public class Install {
      * @param path    固件文件位置
      */
     public static void invokeUpdate(ClassLoader loader, Object context, String path) {
-        Class<?> updateExt = XposedHelpers.findClass("com.mi.fitness.checkupdate.util.CheckUpdateExtKt", loader);
-        Object manager = XposedHelpers.callStaticMethod(updateExt, "getCheckUpdateManager");
+        Class<?> checkUpdateManagerImpl = XposedHelpers.findClass("com.mi.fitness.checkupdate.util.CheckUpdateManagerImpl", loader);
+        Object manager = XposedHelpers.newInstance(checkUpdateManagerImpl);
         // boolean参数为true时为静默安装
         XposedHelpers.callMethod(manager, "manualUpgrade", new Class[]{Context.class, String.class, boolean.class},
                 context, path, false);


### PR DESCRIPTION
3.35.0（24年10月）及以后的版本移除了`com.mi.fitness.checkupdate.util.CheckUpdateExtKt`中的`getCheckUpdateManager`方法，此pr直接实例化`com.mi.fitness.checkupdate.util.CheckUpdateManagerImpl`（与官方代码一致），经小米手环9+小米运动健康3.44.0验证通过。理论上在不那么老的版本也可使用（如3.30.0）。